### PR TITLE
Add HCAD → BigQuery ELT pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# No environment variables are required for local runs.
+# Authentication uses Application Default Credentials via gcloud:
+#
+#   gcloud auth application-default login
+#
+# Optional overrides (uncomment and set if needed):
+# GOOGLE_CLOUD_PROJECT=zwickfi
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # home-property-tax
-Repo housing home property tax analysis to support property tax protests.
+
+HCAD (Harris County Appraisal District) data pipeline and property tax protest analysis. Extracts public data from HCAD and loads it into BigQuery (`zwickfi.hcad`) for analysis.
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `zwickfi.hcad.real_acct` | Real property account and valuation data (2005–present) |
+| `zwickfi.hcad.arb_hearings_real` | Appraisal Review Board hearing records (2005–present) |
+
+## Setup
+
+**Prerequisites:** Python 3.11+, gcloud CLI authenticated to the `zwickfi` project.
+
+```bash
+# Authenticate (one-time)
+gcloud auth application-default login
+
+# Install dependencies
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Running the pipeline
+
+```bash
+# Smart mode — full history on first run, prior + current year on subsequent runs
+python run.py
+
+# Load specific years
+python run.py --years 2024 2025
+
+# Force reload all history (2005–present)
+python run.py --full-refresh
+```
+
+The pipeline is idempotent — re-running the same years is safe, existing rows are replaced.
+
+## Analysis
+
+Property tax protest analysis lives in [`wickersham/tax_year_2023/`](wickersham/tax_year_2023/). The Jupyter notebooks there query the BigQuery tables (or the legacy SQLite database) to produce neighborhood comparables, market trend charts, and protest evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hcad-etl"
+version = "0.1.0"
+description = "HCAD → BigQuery ELT pipeline for Harris County property tax data"
+requires-python = ">=3.11"
+dependencies = [
+    "google-cloud-bigquery[pandas]>=3.11",
+    "db-dtypes>=1.1",
+    "pandas>=2.0",
+    "requests>=2.31",
+]
+
+[project.scripts]
+hcad-etl = "hcad_etl.pipeline:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/run.py
+++ b/run.py
@@ -1,0 +1,5 @@
+"""Convenience entrypoint — equivalent to `python -m hcad_etl.pipeline`."""
+from hcad_etl.pipeline import main
+
+if __name__ == "__main__":
+    main()

--- a/src/hcad_etl/config.py
+++ b/src/hcad_etl/config.py
@@ -1,0 +1,18 @@
+HCAD_BASE_URL = "https://download.hcad.org/data/CAMA"
+FIRST_YEAR = 2005
+
+BQ_PROJECT = "zwickfi"
+BQ_DATASET = "hcad"
+BQ_LOCATION = "US"
+
+# Maps table name → (zip file stem, tsv file stem)
+TABLES = {
+    "real_acct": ("Real_acct_owner", "real_acct"),
+    "arb_hearings_real": ("Hearing_files", "arb_hearings_real"),
+}
+
+# Column used to identify which year a row belongs to, per table
+YEAR_COLUMNS = {
+    "real_acct": "yr",
+    "arb_hearings_real": "Tax_Year",
+}

--- a/src/hcad_etl/extract.py
+++ b/src/hcad_etl/extract.py
@@ -1,0 +1,41 @@
+import io
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+from .config import HCAD_BASE_URL
+
+
+def download_and_extract(year: int, zip_stem: str, tsv_stem: str, tmp_dir: Path) -> pd.DataFrame:
+    """Download a single year's zip from HCAD and return the TSV as a DataFrame."""
+    url = f"{HCAD_BASE_URL}/{year}/{zip_stem}.zip"
+    print(f"  Downloading {url}")
+    response = requests.get(url, stream=True, timeout=300)
+    response.raise_for_status()
+
+    with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+        # Find the target file — HCAD sometimes includes extra files in the zip
+        target = next(
+            (name for name in zf.namelist() if Path(name).stem.lower() == tsv_stem.lower()),
+            None,
+        )
+        if target is None:
+            available = zf.namelist()
+            raise FileNotFoundError(
+                f"Could not find {tsv_stem}.txt in {zip_stem}.zip for {year}. "
+                f"Available files: {available}"
+            )
+        extract_path = tmp_dir / f"{tsv_stem}_{year}.txt"
+        extract_path.write_bytes(zf.read(target))
+
+    df = pd.read_csv(
+        extract_path,
+        sep="\t",
+        encoding="latin1",
+        low_memory=False,
+        on_bad_lines="skip",
+    )
+    extract_path.unlink()
+    return df

--- a/src/hcad_etl/load.py
+++ b/src/hcad_etl/load.py
@@ -1,0 +1,51 @@
+import pandas as pd
+from google.cloud import bigquery
+from google.api_core.exceptions import NotFound
+
+from .config import BQ_PROJECT, BQ_DATASET, BQ_LOCATION, YEAR_COLUMNS
+
+
+def get_client() -> bigquery.Client:
+    return bigquery.Client(project=BQ_PROJECT)
+
+
+def ensure_dataset_exists(client: bigquery.Client) -> None:
+    dataset_ref = bigquery.DatasetReference(BQ_PROJECT, BQ_DATASET)
+    try:
+        client.get_dataset(dataset_ref)
+    except NotFound:
+        dataset = bigquery.Dataset(dataset_ref)
+        dataset.location = BQ_LOCATION
+        client.create_dataset(dataset)
+        print(f"Created dataset {BQ_PROJECT}.{BQ_DATASET}")
+
+
+def delete_year(client: bigquery.Client, table_name: str, year: int) -> None:
+    """Remove all rows for a given year so re-loading is idempotent."""
+    year_col = YEAR_COLUMNS[table_name]
+    full_table = f"`{BQ_PROJECT}.{BQ_DATASET}.{table_name}`"
+    dml = f"DELETE FROM {full_table} WHERE CAST({year_col} AS STRING) = '{year}'"
+    job = client.query(dml)
+    job.result()
+
+
+def table_exists(client: bigquery.Client, table_name: str) -> bool:
+    table_ref = f"{BQ_PROJECT}.{BQ_DATASET}.{table_name}"
+    try:
+        client.get_table(table_ref)
+        return True
+    except NotFound:
+        return False
+
+
+def load_dataframe(client: bigquery.Client, df: pd.DataFrame, table_name: str) -> int:
+    """Append a DataFrame to a BigQuery table. Returns number of rows written."""
+    table_ref = f"{BQ_PROJECT}.{BQ_DATASET}.{table_name}"
+    job_config = bigquery.LoadJobConfig(
+        write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+        create_disposition=bigquery.CreateDisposition.CREATE_IF_NEEDED,
+        autodetect=True,
+    )
+    job = client.load_table_from_dataframe(df, table_ref, job_config=job_config)
+    job.result()
+    return len(df)

--- a/src/hcad_etl/pipeline.py
+++ b/src/hcad_etl/pipeline.py
@@ -1,0 +1,93 @@
+"""HCAD → BigQuery pipeline orchestration."""
+
+import argparse
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+from google.cloud import bigquery
+
+from .config import FIRST_YEAR, TABLES
+from .extract import download_and_extract
+from .load import delete_year, ensure_dataset_exists, get_client, load_dataframe, table_exists
+from .transform import apply_schema
+
+
+def get_years_to_load(client: bigquery.Client, full_refresh: bool) -> list[int]:
+    current_year = datetime.now().year
+    if full_refresh:
+        return list(range(FIRST_YEAR, current_year + 1))
+
+    if not table_exists(client, "real_acct"):
+        print("No existing data found — running full history load.")
+        return list(range(FIRST_YEAR, current_year + 1))
+
+    rows = client.query(
+        "SELECT MAX(CAST(yr AS INT64)) FROM `zwickfi.hcad.real_acct`"
+    ).result()
+    max_year = list(rows)[0][0]
+
+    if max_year is None:
+        print("Table exists but is empty — running full history load.")
+        return list(range(FIRST_YEAR, current_year + 1))
+
+    print(f"Existing data found through {max_year}. Loading incremental years.")
+    return [current_year - 1, current_year]
+
+
+def run_pipeline(years: list[int] | None = None, full_refresh: bool = False) -> None:
+    client = get_client()
+    ensure_dataset_exists(client)
+
+    if years is not None:
+        years_to_load = years
+        print(f"Loading specified years: {years_to_load}")
+    else:
+        years_to_load = get_years_to_load(client, full_refresh)
+        print(f"Years to load: {years_to_load[0]}–{years_to_load[-1]} ({len(years_to_load)} years)")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for year in years_to_load:
+            for table_name, (zip_stem, tsv_stem) in TABLES.items():
+                print(f"\n[{year}] {table_name}")
+                try:
+                    df = download_and_extract(year, zip_stem, tsv_stem, tmp_dir)
+                    df = apply_schema(df, table_name)
+
+                    if table_exists(client, table_name):
+                        delete_year(client, table_name, year)
+
+                    rows = load_dataframe(client, df, table_name)
+                    print(f"  Loaded {rows:,} rows → zwickfi.hcad.{table_name}")
+                except Exception as exc:
+                    print(f"  ERROR: {exc}")
+                    print(f"  Skipping {table_name} for {year}.")
+
+    print("\nDone.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract HCAD data and load into BigQuery (zwickfi.hcad)."
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--full-refresh",
+        action="store_true",
+        help=f"Load all years from {FIRST_YEAR} to present, replacing existing data.",
+    )
+    group.add_argument(
+        "--years",
+        nargs="+",
+        type=int,
+        metavar="YEAR",
+        help="Specific years to load (e.g. --years 2024 2025).",
+    )
+    args = parser.parse_args()
+
+    run_pipeline(years=args.years, full_refresh=args.full_refresh)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hcad_etl/transform.py
+++ b/src/hcad_etl/transform.py
@@ -1,0 +1,34 @@
+import pandas as pd
+
+
+def apply_schema_real_acct(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    df["acct"] = df["acct"].astype(str)
+    df["yr"] = df["yr"].astype(str)
+    for col in ("certified_date", "notice_dt", "rev_dt", "new_own_dt", "splt_dt"):
+        if col in df.columns:
+            df[col] = pd.to_datetime(df[col], errors="coerce")
+    return df
+
+
+def apply_schema_arb_hearings_real(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    df["acct"] = df["acct"].astype(str)
+    df["Tax_Year"] = df["Tax_Year"].astype(str)
+    for col in ("Scheduled_for_Date", "Actual_Hearing_Date", "Release_Date"):
+        if col in df.columns:
+            df[col] = pd.to_datetime(df[col], errors="coerce")
+    return df
+
+
+SCHEMA_FUNCTIONS = {
+    "real_acct": apply_schema_real_acct,
+    "arb_hearings_real": apply_schema_arb_hearings_real,
+}
+
+
+def apply_schema(df: pd.DataFrame, table_name: str) -> pd.DataFrame:
+    fn = SCHEMA_FUNCTIONS.get(table_name)
+    if fn is None:
+        raise ValueError(f"No schema function defined for table: {table_name}")
+    return fn(df)


### PR DESCRIPTION
## Summary

- Replaces the Jupyter notebook ETL workflow with a structured Python package (`src/hcad_etl/`) that downloads HCAD public data and loads it into BigQuery (`zwickfi.hcad`)
- Two tables loaded: `real_acct` (property valuations) and `arb_hearings_real` (ARB hearing records), 2005–present
- Smart incremental logic: first run loads full history; subsequent runs reload only the prior and current year

## Usage

```bash
python3.11 -m venv .venv && source .venv/bin/activate && pip install -e .
gcloud auth application-default login

python run.py                    # smart mode
python run.py --years 2024 2025  # specific years
python run.py --full-refresh     # force full reload
```

## Notes for reviewer

- Each run is idempotent — rows for a year are deleted before re-inserting, so re-running is safe
- A single year (2009 `real_acct`) timed out on HCAD's server during the initial load; can be backfilled with `python run.py --years 2009`
- Auth uses Application Default Credentials (gcloud OAuth); no service account needed for local runs
- Existing notebooks and analysis in `wickersham/` are preserved untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)